### PR TITLE
Poganjanje na Binderju

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,2 @@
 jupyter-server-proxy
 psycopg2
-hashlib
-datetime

--- a/gama.py
+++ b/gama.py
@@ -1,6 +1,6 @@
 
 from bottle import *
-from auth import *
+from auth_public import *
 import hashlib
 from bottleext import *
 from datetime import date
@@ -11,9 +11,16 @@ from datetime import date
 import psycopg2, psycopg2.extensions, psycopg2.extras
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 
+import os
+
+# privzete nastavitve
+SERVER_PORT = os.environ.get('BOTTLE_PORT', 8080)
+RELOADER = os.environ.get('BOTTLE_RELOADER', True)
+DB_PORT = os.environ.get('POSTGRES_PORT', 5432)
+
 
 # PRIKLOP NA BAZO
-conn = psycopg2.connect(database=db, host=host, user=user, password=password)
+conn = psycopg2.connect(database=db, host=host, user=user, password=password, port=DB_PORT)
 cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor) 
 # Odkomentiraj, če želiš sporočila o napakah
 debug(True)  # za izpise pri razvoju
@@ -411,5 +418,5 @@ def odjava():
     #response.delete_cookie("id", path='/')
     redirect(url('index'))
 
-run(host='localhost', port=8080, reloader=True)
+run(host='localhost', port=SERVER_PORT, reloader=RELOADER)
 


### PR DESCRIPTION
Tukaj je še nekaj stvari, potrebnih za poganjanje na Binderju. Iz `requirements.txt` sem odstranil knjižnici `datetime` in `hashlib`, saj sta že vgrajeni v Python - poleg tega pri poskusu namestitve (novejše različice) slednje pride do napake. Poleg tega sem v `gama.py` dodal še branje nastavitev iz okolja, da bo delovala povezava na bazo in se bodo URL-ji ustrezno zgradili.

Svetujem, da čim prej poskrbite za pravice uporabnika `javnost` (oziroma vsaj za osnovne pravice, da bo povezava na bazo uspela). Poleg tega, kot rečeno v #1, poglejte po predlogah, kje imate še navedene absolutne poti, in namesto tega uporabite funkcijo `url`.

Da sprejmete tele spremembe, kliknite na **Merge pull request**, potem pa naredite še pull, da jih pridobite k sebi.